### PR TITLE
Revise owl:sameAs usage

### DIFF
--- a/mappings/rml/biobanks.rml.ttl
+++ b/mappings/rml/biobanks.rml.ttl
@@ -7,7 +7,6 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix grel: <http://users.ugent.be/~bjdmeest/function/grel.ttl#> .
-@prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix nf:   <http://nf-osi.github.com/terms#> .
 @prefix map:  <http://nf-osi.github.com/mappings/biobanks#> .
 
@@ -31,7 +30,7 @@ map:BiobankCore a rr:TriplesMap ;
     rr:predicateObjectMap [ rr:predicate nf:name ; rr:objectMap [ rml:reference "biobankName" ; rr:datatype xsd:string ] ] ;
     rr:predicateObjectMap [ rr:predicate nf:biobankURL ; rr:objectMap [ rml:reference "biobankURL" ; rr:termType rr:IRI ] ] ;
     rr:predicateObjectMap [ rr:predicate nf:contact ; rr:objectMap [ rml:reference "contact" ; rr:datatype xsd:string ] ] ;
-    rr:predicateObjectMap [ rr:predicate owl:sameAs ; rr:objectMap [ rr:template "http://nf-osi.github.com/terms#resource/{resourceId}" ; rr:termType rr:IRI ] ] .
+    rr:predicateObjectMap [ rr:predicate nf:resourceId ; rr:objectMap [ rml:reference "resourceId" ; rr:datatype xsd:string ] ] .
 
 ################################################################################
 # Multi-valued fields (StringList, pipe-delimited)

--- a/mappings/rml/development.rml.ttl
+++ b/mappings/rml/development.rml.ttl
@@ -28,13 +28,13 @@ map:DevelopmentCore a rr:TriplesMap ;
 # Development -> Resource relationship
 ################################################################################
 
-map:DevelopmentHasResource a rr:TriplesMap ;
-    rdfs:label "Development Has Resource" ;
+map:DevelopmentAboutResourceId a rr:TriplesMap ;
+    rdfs:label "Development About Resource ID" ;
     rml:logicalSource map:DevelopmentSource ;
     rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#development/{developmentId}" ; rr:termType rr:IRI ] ;
     rr:predicateObjectMap [
-        rr:predicate nf:hasResource ;
-        rr:objectMap [ rr:template "http://nf-osi.github.com/terms#resource/{resourceId}" ; rr:termType rr:IRI ]
+        rr:predicate nf:forResourceId ;
+        rr:objectMap [ rml:reference "resourceId" ; rr:datatype xsd:string ]
     ] .
 
 ################################################################################

--- a/mappings/rml/observations.rml.ttl
+++ b/mappings/rml/observations.rml.ttl
@@ -65,8 +65,8 @@ map:ObservationAboutResource a rr:TriplesMap ;
         rr:termType rr:IRI
     ] ;
     rr:predicateObjectMap [
-        rr:predicate nf:aboutResource ;
-        rr:objectMap [ rr:template "https://nf.synapse.org/Explore/Tools/DetailsPage/Details?resourceId={resourceId}" ; rr:termType rr:IRI ]
+        rr:predicate nf:forResourceId ;
+        rr:objectMap [ rml:reference "resourceId" ; rr:datatype xsd:string ]
     ] .
 
 ################################################################################

--- a/mappings/rml/resources.rml.ttl
+++ b/mappings/rml/resources.rml.ttl
@@ -5,7 +5,6 @@
 @prefix ql:   <http://semweb.mmlab.be/ns/ql#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix grel: <http://users.ugent.be/~bjdmeest/function/grel.ttl#> .
 @prefix nf:   <http://nf-osi.github.com/terms#> .
@@ -20,14 +19,15 @@ map:ResourcesSource a rml:LogicalSource ;
     rml:referenceFormulation ql:CSV .
 
 ################################################################################
-# Resource core properties
+# Cell Line
 ################################################################################
 
-map:ResourceCore a rr:TriplesMap ;
-    rdfs:label "Resource Core" ;
+map:CellLineCore a rr:TriplesMap ;
+    rdfs:label "Cell Line Core" ;
     rml:logicalSource map:ResourcesSource ;
-    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#resource/{resourceId}" ; rr:termType rr:IRI ] ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#cellLine/{cellLineId}" ; rr:termType rr:IRI ] ;
     rr:predicateObjectMap [ rr:predicate rdf:type ; rr:objectMap [ rr:constant nf:Tool ; rr:termType rr:IRI ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:resourceId ; rr:objectMap [ rml:reference "resourceId" ; rr:datatype xsd:string ] ] ;
     rr:predicateObjectMap [ rr:predicate nf:name ; rr:objectMap [ rml:reference "resourceName" ; rr:datatype xsd:string ] ] ;
     rr:predicateObjectMap [ rr:predicate nf:resourceType ; rr:objectMap [ rml:reference "resourceType" ; rr:datatype xsd:string ] ] ;
     rr:predicateObjectMap [ rr:predicate nf:description ; rr:objectMap [ rml:reference "description" ; rr:datatype xsd:string ] ] ;
@@ -36,14 +36,10 @@ map:ResourceCore a rr:TriplesMap ;
     rr:predicateObjectMap [ rr:predicate nf:dateAdded ; rr:objectMap [ rml:reference "dateAdded" ; rr:datatype xsd:long ] ] ;
     rr:predicateObjectMap [ rr:predicate nf:dateModified ; rr:objectMap [ rml:reference "dateModified" ; rr:datatype xsd:long ] ] .
 
-################################################################################
-# Resource list properties (pipe-delimited)
-################################################################################
-
-map:ResourceUsageRequirements a rr:TriplesMap ;
-    rdfs:label "Resource Usage Requirements" ;
+map:CellLineUsageRequirements a rr:TriplesMap ;
+    rdfs:label "Cell Line Usage Requirements" ;
     rml:logicalSource map:ResourcesSource ;
-    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#resource/{resourceId}" ; rr:termType rr:IRI ] ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#cellLine/{cellLineId}" ; rr:termType rr:IRI ] ;
     rr:predicateObjectMap [
         rr:predicate nf:usageRequirements ;
         rr:objectMap [
@@ -68,10 +64,10 @@ map:ResourceUsageRequirements a rr:TriplesMap ;
         ]
     ] .
 
-map:ResourceSynonyms a rr:TriplesMap ;
-    rdfs:label "Resource Synonyms" ;
+map:CellLineSynonyms a rr:TriplesMap ;
+    rdfs:label "Cell Line Synonyms" ;
     rml:logicalSource map:ResourcesSource ;
-    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#resource/{resourceId}" ; rr:termType rr:IRI ] ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#cellLine/{cellLineId}" ; rr:termType rr:IRI ] ;
     rr:predicateObjectMap [
         rr:predicate nf:synonyms ;
         rr:objectMap [
@@ -97,50 +93,297 @@ map:ResourceSynonyms a rr:TriplesMap ;
     ] .
 
 ################################################################################
-# owl:sameAs relationships to tool-specific IDs
+# Antibody
 ################################################################################
 
-map:ResourceToGeneticReagent a rr:TriplesMap ;
-    rdfs:label "Resource to Genetic Reagent ID" ;
+map:AntibodyCore a rr:TriplesMap ;
+    rdfs:label "Antibody Core" ;
     rml:logicalSource map:ResourcesSource ;
-    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#resource/{resourceId}" ; rr:termType rr:IRI ] ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#antibody/{antibodyId}" ; rr:termType rr:IRI ] ;
+    rr:predicateObjectMap [ rr:predicate rdf:type ; rr:objectMap [ rr:constant nf:Tool ; rr:termType rr:IRI ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:resourceId ; rr:objectMap [ rml:reference "resourceId" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:name ; rr:objectMap [ rml:reference "resourceName" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:resourceType ; rr:objectMap [ rml:reference "resourceType" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:description ; rr:objectMap [ rml:reference "description" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:rrid ; rr:objectMap [ rml:reference "rrid" ; rr:termType rr:IRI ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:howToAcquire ; rr:objectMap [ rml:reference "howToAcquire" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:dateAdded ; rr:objectMap [ rml:reference "dateAdded" ; rr:datatype xsd:long ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:dateModified ; rr:objectMap [ rml:reference "dateModified" ; rr:datatype xsd:long ] ] .
+
+map:AntibodyUsageRequirements a rr:TriplesMap ;
+    rdfs:label "Antibody Usage Requirements" ;
+    rml:logicalSource map:ResourcesSource ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#antibody/{antibodyId}" ; rr:termType rr:IRI ] ;
     rr:predicateObjectMap [
-        rr:predicate owl:sameAs ;
-        rr:objectMap [ rr:template "http://nf-osi.github.com/terms#geneticReagent/{geneticReagentId}" ; rr:termType rr:IRI ]
+        rr:predicate nf:usageRequirements ;
+        rr:objectMap [
+            a fnml:FunctionTermMap ;
+            rr:datatype xsd:string ;
+            fnml:functionValue [
+                a fno:Execution ;
+                rml:logicalSource map:ResourcesSource ;
+                rr:predicateObjectMap [
+                    rr:predicate fno:executes ;
+                    rr:objectMap [ rr:constant grel:string_split ; rr:termType rr:IRI ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:valueParameter ;
+                    rr:objectMap [ rml:reference "usageRequirements" ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:p_string_sep ;
+                    rr:objectMap [ rr:constant "\\|" ; rr:termType rr:Literal ]
+                ]
+            ]
+        ]
     ] .
 
-map:ResourceToAntibody a rr:TriplesMap ;
-    rdfs:label "Resource to Antibody ID" ;
+map:AntibodySynonyms a rr:TriplesMap ;
+    rdfs:label "Antibody Synonyms" ;
     rml:logicalSource map:ResourcesSource ;
-    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#resource/{resourceId}" ; rr:termType rr:IRI ] ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#antibody/{antibodyId}" ; rr:termType rr:IRI ] ;
     rr:predicateObjectMap [
-        rr:predicate owl:sameAs ;
-        rr:objectMap [ rr:template "http://nf-osi.github.com/terms#antibody/{antibodyId}" ; rr:termType rr:IRI ]
+        rr:predicate nf:synonyms ;
+        rr:objectMap [
+            a fnml:FunctionTermMap ;
+            rr:datatype xsd:string ;
+            fnml:functionValue [
+                a fno:Execution ;
+                rml:logicalSource map:ResourcesSource ;
+                rr:predicateObjectMap [
+                    rr:predicate fno:executes ;
+                    rr:objectMap [ rr:constant grel:string_split ; rr:termType rr:IRI ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:valueParameter ;
+                    rr:objectMap [ rml:reference "synonyms" ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:p_string_sep ;
+                    rr:objectMap [ rr:constant "\\|" ; rr:termType rr:Literal ]
+                ]
+            ]
+        ]
     ] .
 
-map:ResourceToCellLine a rr:TriplesMap ;
-    rdfs:label "Resource to Cell Line ID" ;
+################################################################################
+# Animal Model
+################################################################################
+
+map:AnimalModelCore a rr:TriplesMap ;
+    rdfs:label "Animal Model Core" ;
     rml:logicalSource map:ResourcesSource ;
-    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#resource/{resourceId}" ; rr:termType rr:IRI ] ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#animalModel/{animalModelId}" ; rr:termType rr:IRI ] ;
+    rr:predicateObjectMap [ rr:predicate rdf:type ; rr:objectMap [ rr:constant nf:Tool ; rr:termType rr:IRI ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:resourceId ; rr:objectMap [ rml:reference "resourceId" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:name ; rr:objectMap [ rml:reference "resourceName" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:resourceType ; rr:objectMap [ rml:reference "resourceType" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:description ; rr:objectMap [ rml:reference "description" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:rrid ; rr:objectMap [ rml:reference "rrid" ; rr:termType rr:IRI ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:howToAcquire ; rr:objectMap [ rml:reference "howToAcquire" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:dateAdded ; rr:objectMap [ rml:reference "dateAdded" ; rr:datatype xsd:long ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:dateModified ; rr:objectMap [ rml:reference "dateModified" ; rr:datatype xsd:long ] ] .
+
+map:AnimalModelUsageRequirements a rr:TriplesMap ;
+    rdfs:label "Animal Model Usage Requirements" ;
+    rml:logicalSource map:ResourcesSource ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#animalModel/{animalModelId}" ; rr:termType rr:IRI ] ;
     rr:predicateObjectMap [
-        rr:predicate owl:sameAs ;
-        rr:objectMap [ rr:template "http://nf-osi.github.com/terms#cellLine/{cellLineId}" ; rr:termType rr:IRI ]
+        rr:predicate nf:usageRequirements ;
+        rr:objectMap [
+            a fnml:FunctionTermMap ;
+            rr:datatype xsd:string ;
+            fnml:functionValue [
+                a fno:Execution ;
+                rml:logicalSource map:ResourcesSource ;
+                rr:predicateObjectMap [
+                    rr:predicate fno:executes ;
+                    rr:objectMap [ rr:constant grel:string_split ; rr:termType rr:IRI ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:valueParameter ;
+                    rr:objectMap [ rml:reference "usageRequirements" ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:p_string_sep ;
+                    rr:objectMap [ rr:constant "\\|" ; rr:termType rr:Literal ]
+                ]
+            ]
+        ]
     ] .
 
-map:ResourceToAnimalModel a rr:TriplesMap ;
-    rdfs:label "Resource to Animal Model ID" ;
+map:AnimalModelSynonyms a rr:TriplesMap ;
+    rdfs:label "Animal Model Synonyms" ;
     rml:logicalSource map:ResourcesSource ;
-    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#resource/{resourceId}" ; rr:termType rr:IRI ] ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#animalModel/{animalModelId}" ; rr:termType rr:IRI ] ;
     rr:predicateObjectMap [
-        rr:predicate owl:sameAs ;
-        rr:objectMap [ rr:template "http://nf-osi.github.com/terms#animalModel/{animalModelId}" ; rr:termType rr:IRI ]
+        rr:predicate nf:synonyms ;
+        rr:objectMap [
+            a fnml:FunctionTermMap ;
+            rr:datatype xsd:string ;
+            fnml:functionValue [
+                a fno:Execution ;
+                rml:logicalSource map:ResourcesSource ;
+                rr:predicateObjectMap [
+                    rr:predicate fno:executes ;
+                    rr:objectMap [ rr:constant grel:string_split ; rr:termType rr:IRI ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:valueParameter ;
+                    rr:objectMap [ rml:reference "synonyms" ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:p_string_sep ;
+                    rr:objectMap [ rr:constant "\\|" ; rr:termType rr:Literal ]
+                ]
+            ]
+        ]
     ] .
 
-map:ResourceToBiobank a rr:TriplesMap ;
-    rdfs:label "Resource to Biobank ID" ;
+################################################################################
+# Genetic Reagent
+################################################################################
+
+map:GeneticReagentCore a rr:TriplesMap ;
+    rdfs:label "Genetic Reagent Core" ;
     rml:logicalSource map:ResourcesSource ;
-    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#resource/{resourceId}" ; rr:termType rr:IRI ] ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#geneticReagent/{geneticReagentId}" ; rr:termType rr:IRI ] ;
+    rr:predicateObjectMap [ rr:predicate rdf:type ; rr:objectMap [ rr:constant nf:Tool ; rr:termType rr:IRI ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:resourceId ; rr:objectMap [ rml:reference "resourceId" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:name ; rr:objectMap [ rml:reference "resourceName" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:resourceType ; rr:objectMap [ rml:reference "resourceType" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:description ; rr:objectMap [ rml:reference "description" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:rrid ; rr:objectMap [ rml:reference "rrid" ; rr:termType rr:IRI ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:howToAcquire ; rr:objectMap [ rml:reference "howToAcquire" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:dateAdded ; rr:objectMap [ rml:reference "dateAdded" ; rr:datatype xsd:long ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:dateModified ; rr:objectMap [ rml:reference "dateModified" ; rr:datatype xsd:long ] ] .
+
+map:GeneticReagentUsageRequirements a rr:TriplesMap ;
+    rdfs:label "Genetic Reagent Usage Requirements" ;
+    rml:logicalSource map:ResourcesSource ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#geneticReagent/{geneticReagentId}" ; rr:termType rr:IRI ] ;
     rr:predicateObjectMap [
-        rr:predicate owl:sameAs ;
-        rr:objectMap [ rr:template "http://nf-osi.github.com/terms#biobank/{biobankId}" ; rr:termType rr:IRI ]
+        rr:predicate nf:usageRequirements ;
+        rr:objectMap [
+            a fnml:FunctionTermMap ;
+            rr:datatype xsd:string ;
+            fnml:functionValue [
+                a fno:Execution ;
+                rml:logicalSource map:ResourcesSource ;
+                rr:predicateObjectMap [
+                    rr:predicate fno:executes ;
+                    rr:objectMap [ rr:constant grel:string_split ; rr:termType rr:IRI ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:valueParameter ;
+                    rr:objectMap [ rml:reference "usageRequirements" ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:p_string_sep ;
+                    rr:objectMap [ rr:constant "\\|" ; rr:termType rr:Literal ]
+                ]
+            ]
+        ]
+    ] .
+
+map:GeneticReagentSynonyms a rr:TriplesMap ;
+    rdfs:label "Genetic Reagent Synonyms" ;
+    rml:logicalSource map:ResourcesSource ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#geneticReagent/{geneticReagentId}" ; rr:termType rr:IRI ] ;
+    rr:predicateObjectMap [
+        rr:predicate nf:synonyms ;
+        rr:objectMap [
+            a fnml:FunctionTermMap ;
+            rr:datatype xsd:string ;
+            fnml:functionValue [
+                a fno:Execution ;
+                rml:logicalSource map:ResourcesSource ;
+                rr:predicateObjectMap [
+                    rr:predicate fno:executes ;
+                    rr:objectMap [ rr:constant grel:string_split ; rr:termType rr:IRI ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:valueParameter ;
+                    rr:objectMap [ rml:reference "synonyms" ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:p_string_sep ;
+                    rr:objectMap [ rr:constant "\\|" ; rr:termType rr:Literal ]
+                ]
+            ]
+        ]
+    ] .
+
+################################################################################
+# Biobank
+################################################################################
+
+map:BiobankCore a rr:TriplesMap ;
+    rdfs:label "Biobank Core" ;
+    rml:logicalSource map:ResourcesSource ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#biobank/{biobankId}" ; rr:termType rr:IRI ] ;
+    rr:predicateObjectMap [ rr:predicate rdf:type ; rr:objectMap [ rr:constant nf:Tool ; rr:termType rr:IRI ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:resourceId ; rr:objectMap [ rml:reference "resourceId" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:name ; rr:objectMap [ rml:reference "resourceName" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:resourceType ; rr:objectMap [ rml:reference "resourceType" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:description ; rr:objectMap [ rml:reference "description" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:rrid ; rr:objectMap [ rml:reference "rrid" ; rr:termType rr:IRI ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:howToAcquire ; rr:objectMap [ rml:reference "howToAcquire" ; rr:datatype xsd:string ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:dateAdded ; rr:objectMap [ rml:reference "dateAdded" ; rr:datatype xsd:long ] ] ;
+    rr:predicateObjectMap [ rr:predicate nf:dateModified ; rr:objectMap [ rml:reference "dateModified" ; rr:datatype xsd:long ] ] .
+
+map:BiobankUsageRequirements a rr:TriplesMap ;
+    rdfs:label "Biobank Usage Requirements" ;
+    rml:logicalSource map:ResourcesSource ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#biobank/{biobankId}" ; rr:termType rr:IRI ] ;
+    rr:predicateObjectMap [
+        rr:predicate nf:usageRequirements ;
+        rr:objectMap [
+            a fnml:FunctionTermMap ;
+            rr:datatype xsd:string ;
+            fnml:functionValue [
+                a fno:Execution ;
+                rml:logicalSource map:ResourcesSource ;
+                rr:predicateObjectMap [
+                    rr:predicate fno:executes ;
+                    rr:objectMap [ rr:constant grel:string_split ; rr:termType rr:IRI ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:valueParameter ;
+                    rr:objectMap [ rml:reference "usageRequirements" ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:p_string_sep ;
+                    rr:objectMap [ rr:constant "\\|" ; rr:termType rr:Literal ]
+                ]
+            ]
+        ]
+    ] .
+
+map:BiobankSynonyms a rr:TriplesMap ;
+    rdfs:label "Biobank Synonyms" ;
+    rml:logicalSource map:ResourcesSource ;
+    rr:subjectMap [ rr:template "http://nf-osi.github.com/terms#biobank/{biobankId}" ; rr:termType rr:IRI ] ;
+    rr:predicateObjectMap [
+        rr:predicate nf:synonyms ;
+        rr:objectMap [
+            a fnml:FunctionTermMap ;
+            rr:datatype xsd:string ;
+            fnml:functionValue [
+                a fno:Execution ;
+                rml:logicalSource map:ResourcesSource ;
+                rr:predicateObjectMap [
+                    rr:predicate fno:executes ;
+                    rr:objectMap [ rr:constant grel:string_split ; rr:termType rr:IRI ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:valueParameter ;
+                    rr:objectMap [ rml:reference "synonyms" ]
+                ] ;
+                rr:predicateObjectMap [
+                    rr:predicate grel:p_string_sep ;
+                    rr:objectMap [ rr:constant "\\|" ; rr:termType rr:Literal ]
+                ]
+            ]
+        ]
     ] .

--- a/schema/ontology.ttl
+++ b/schema/ontology.ttl
@@ -45,7 +45,7 @@ nf:CRISPRReagent a owl:Class ;
 
 nf:sgRNA a owl:Class ;
     rdfs:subClassOf nf:CRISPRReagent ; 
-    owl:sameAs obo:SO_0001998 ;
+    owl:equivalentClass obo:SO_0001998 ;
     rdfs:label "sgRNA" ;
     rdfs:comment "Single guide RNA used in CRISPR experiments." .
 
@@ -71,7 +71,7 @@ nf:MouseTargetingVector a owl:Class ;
 
 nf:RNAiReagent a owl:Class ;
     rdfs:subClassOf nf:GeneticReagent ;
-    owl:sameAs obo:SO_0000337 ;
+    owl:equivalentClass obo:SO_0000337 ;
     rdfs:label "RNAi Reagent" .
 
 nf:TransferVector a owl:Class ;
@@ -174,7 +174,7 @@ nf:UnspecifiedMutation a owl:Class ;
     rdfs:comment "A mutation whose type is not specified." .
 
 nf:Genotype a owl:Class ;
-    owl:sameAs efo:EFO_0000513 ;
+    owl:equivalentClass efo:EFO_0000513 ;
     rdfs:label "Genotype" ;
     rdfs:comment "The genetic makeup at a specific locus." .
 
@@ -229,7 +229,7 @@ nf:CellLine a owl:Class ;
 
 nf:CancerCellLine a owl:Class ;
     rdfs:subClassOf nf:CellLine ;
-    owl:sameAs efo:EFO_0001639 ;
+    owl:equivalentClass efo:EFO_0001639 ;
     rdfs:label "Cancer Cell Line" ;
     rdfs:comment "A cell line derived from cancerous tissue." .
 
@@ -240,7 +240,7 @@ nf:TransformedCellLine a owl:Class ;
 
 nf:InducedPluripotentStemCellLine a owl:Class ;
     rdfs:subClassOf nf:CellLine ;
-    owl:sameAs efo:EFO_0005740;
+    owl:equivalentClass efo:EFO_0005740;
     rdfs:label "Induced Pluripotent Stem Cell Line" ;
     rdfs:comment "A cell line derived from iPS cells." .
 
@@ -251,7 +251,7 @@ nf:TelomeraseImmortalizedCellLine a owl:Class ;
 
 nf:EmbryonicStemCellLine a owl:Class ;
     rdfs:subClassOf nf:CellLine ;
-    owl:sameAs efo:EFO_0005738 ;
+    owl:equivalentClass efo:EFO_0005738 ;
     rdfs:label "Embryonic Stem Cell" ;
     rdfs:comment "A cell line derived from embryonic stem cells." .
 
@@ -287,7 +287,7 @@ nf:Antibody a owl:Class ;
 
 nf:AnimalModel a owl:Class ;
     rdfs:subClassOf nf:Tool ;
-    owl:sameAs efo:EFO_0022953 ;
+    owl:equivalentClass efo:EFO_0022953 ;
     rdfs:label "Animal Model" ;
     rdfs:comment "An animal model used in research." .
 

--- a/schema/shapes.ttl
+++ b/schema/shapes.ttl
@@ -325,6 +325,11 @@ shapes:CellLineShape a sh:NodeShape ;
     rdfs:label "Cell Line shape" ;
     rdfs:comment "Expected properties for CellLine instances." ;
     sh:property [
+        sh:path nf:resourceId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
         sh:path nf:cellLineId ;
         sh:datatype xsd:string ;
         sh:maxCount 1 ;
@@ -396,6 +401,11 @@ shapes:AnimalModelShape a sh:NodeShape ;
     rdfs:label "Animal Model shape" ;
     rdfs:comment "Expected properties for AnimalModel instances." ;
     sh:property [
+        sh:path nf:resourceId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
         sh:path nf:animalModelId ;
         sh:datatype xsd:string ;
         sh:maxCount 1 ;
@@ -462,6 +472,11 @@ shapes:AntibodyShape a sh:NodeShape ;
     rdfs:label "Antibody shape" ;
     rdfs:comment "Expected properties for Antibody instances." ;
     sh:property [
+        sh:path nf:resourceId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
         sh:path nf:antibodyId ;
         sh:datatype xsd:string ;
         sh:maxCount 1 ;
@@ -509,6 +524,11 @@ shapes:GeneticReagentShape a sh:NodeShape ;
     sh:targetClass nf:GeneticReagent ;
     rdfs:label "Genetic Reagent shape" ;
     rdfs:comment "Expected properties for GeneticReagent instances." ;
+    sh:property [
+        sh:path nf:resourceId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
     sh:property [
         sh:path nf:geneticReagentId ;
         sh:datatype xsd:string ;
@@ -658,8 +678,9 @@ shapes:BiobankShape a sh:NodeShape ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
-        sh:path nf:hasResource ;
-        sh:nodeKind sh:IRI ;
+        sh:path nf:resourceId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
     ] ;
     sh:property [
         sh:path nf:diseaseType ;
@@ -806,8 +827,9 @@ shapes:DevelopmentShape a sh:NodeShape ;
     rdfs:label "Development shape" ;
     rdfs:comment "Expected properties for Development instances." ;
     sh:property [
-        sh:path nf:hasResource ;
-        sh:nodeKind sh:IRI ;
+        sh:path nf:forResourceId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
     ] ;
     sh:property [
         sh:path nf:hasFunder ;
@@ -881,8 +903,9 @@ shapes:ObservationShape a sh:NodeShape ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
-        sh:path nf:aboutResource ;
-        sh:nodeKind sh:IRI ;
+        sh:path nf:forResourceId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
     ] ;
     sh:property [
         sh:path nf:referencesPublication ;
@@ -897,6 +920,11 @@ shapes:ToolShape a sh:NodeShape ;
     sh:targetClass nf:Tool ;
     rdfs:label "Tool shape" ;
     rdfs:comment "Expected properties for Tool (Resource) instances." ;
+    sh:property [
+        sh:path nf:resourceId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
     sh:property [
         sh:path nf:name ;
         sh:datatype xsd:string ;

--- a/test/test_rml_biobanks.py
+++ b/test/test_rml_biobanks.py
@@ -68,25 +68,22 @@ class TestBiobanksCore:
             assert isinstance(row.url, URIRef), \
                 f"biobankURL should be IRI, got {type(row.url)}"
 
-    def test_same_as_resource_is_iri(self, biobanks_graph, namespaces):
-        """owl:sameAs should link to a resource IRI"""
+    def test_resource_id_is_string(self, biobanks_graph, namespaces):
+        """resourceId should be a string literal"""
         NF = namespaces["nf"]
-        OWL = Namespace("http://www.w3.org/2002/07/owl#")
 
         query = """
-        SELECT ?biobank ?resource
+        SELECT ?biobank ?resourceId
         WHERE {
             ?biobank a nf:Biobank ;
-                     owl:sameAs ?resource .
+                     nf:resourceId ?resourceId .
         }
         """
-        results = list(biobanks_graph.query(query, initNs={"nf": NF, "owl": OWL}))
-        assert len(results) > 0, "No owl:sameAs relationships found"
+        results = list(biobanks_graph.query(query, initNs={"nf": NF}))
+        assert len(results) > 0, "No resourceId properties found"
         for row in results:
-            assert isinstance(row.resource, URIRef), \
-                f"owl:sameAs should be IRI, got {type(row.resource)}"
-            assert "resource/" in str(row.resource), \
-                f"Expected resource/ IRI pattern, got {row.resource}"
+            assert isinstance(row.resourceId, Literal), \
+                f"resourceId should be Literal, got {type(row.resourceId)}"
 
 
 class TestBiobanksMultiValue:

--- a/test/test_rml_development.py
+++ b/test/test_rml_development.py
@@ -324,19 +324,22 @@ class TestDevelopmentRelationships:
         results = list(development_graph.query(query, initNs={"nf": NF}))
         assert len(results) > 0, "No development-publication relationships found"
 
-    def test_development_has_resource_relationship(self, development_graph, namespaces):
-        """Development entities should link to resources via hasResource"""
+    def test_development_has_resource_id(self, development_graph, namespaces):
+        """Development entities should link to resources via forResourceId"""
         NF = namespaces["nf"]
 
         query = """
-        SELECT ?dev ?resource
+        SELECT ?dev ?resourceId
         WHERE {
-            ?dev nf:hasResource ?resource .
+            ?dev nf:forResourceId ?resourceId .
             FILTER(CONTAINS(STR(?dev), "development/"))
         }
         """
         results = list(development_graph.query(query, initNs={"nf": NF}))
         assert len(results) > 0, "No development-resource relationships found"
+        for row in results:
+            assert isinstance(row.resourceId, Literal), \
+                f"forResourceId should be Literal, got {type(row.resourceId)}"
 
     def test_resource_has_funder_shortcut(self, development_graph, namespaces):
         """Resources should link to funders via hasFunder shortcut"""

--- a/test/test_rml_observations.py
+++ b/test/test_rml_observations.py
@@ -208,24 +208,23 @@ class TestObservationsIRIFields:
 class TestObservationsRelationships:
     """Test observation relationships to other entities"""
 
-    def test_observation_about_resource(self, observations_graph, namespaces):
-        """Observations should link to resources via aboutResource"""
+    def test_observation_for_resource_id(self, observations_graph, namespaces):
+        """Observations should link to resources via forResourceId"""
         NF = namespaces["nf"]
 
         query = """
-        SELECT ?observation ?resource
+        SELECT ?observation ?resourceId
         WHERE {
             ?observation a nf:Observation ;
-                        nf:aboutResource ?resource .
+                        nf:forResourceId ?resourceId .
         }
         """
         results = list(observations_graph.query(query, initNs={"nf": NF}))
-        assert len(results) > 0, "No aboutResource relationships found"
+        assert len(results) > 0, "No forResourceId relationships found"
 
-        # Resource IDs should be IRIs
         for row in results:
-            assert isinstance(row.resource, URIRef), \
-                f"resourceId should be IRI, got {type(row.resource)}"
+            assert isinstance(row.resourceId, Literal), \
+                f"forResourceId should be Literal, got {type(row.resourceId)}"
 
     def test_observation_references_publication(self, observations_graph, namespaces):
         """Observations should link to publications via referencesPublication"""
@@ -251,11 +250,11 @@ class TestObservationsRelationships:
         NF = namespaces["nf"]
 
         query = """
-        SELECT ?observation ?resource ?publication
+        SELECT ?observation ?resourceId ?publication
         WHERE {
-            ?observation nf:aboutResource ?resource ;
+            ?observation nf:forResourceId ?resourceId ;
                         nf:referencesPublication ?publication .
-            FILTER(CONTAINS(STR(?resource), "test-res-001"))
+            FILTER(CONTAINS(STR(?resourceId), "test-res-001"))
         }
         """
         results = list(observations_graph.query(query, initNs={"nf": NF}))

--- a/test/test_rml_resources.py
+++ b/test/test_rml_resources.py
@@ -2,12 +2,12 @@
 Tests for Resources RML mapping
 
 Tests the resources.rml.ttl mapping against test/resources.csv
-Includes owl:sameAs relationships and pipe-delimited fields
+Includes resourceId on tool-specific subjects and pipe-delimited fields
 """
 
 import pytest
 from rdflib import URIRef, Literal
-from rdflib.namespace import RDF, OWL
+from rdflib.namespace import RDF
 
 
 @pytest.fixture
@@ -107,51 +107,48 @@ class TestResourcesIRIFields:
                 f"Expected RRID format, got {row.rrid}"
 
 
-class TestResourcesOwlSameAs:
-    """Test owl:sameAs relationships to tool-specific IDs"""
+class TestResourceIdOnToolSubjects:
+    """Test resourceId datatype property on tool-specific subjects"""
 
-    def test_owl_sameas_relationships_exist(self, resources_graph, namespaces):
-        """Resources should have owl:sameAs to tool-specific IDs"""
+    def test_tool_subjects_have_resource_id(self, resources_graph, namespaces):
+        """Tool-specific subjects should have nf:resourceId"""
         NF = namespaces["nf"]
 
         query = """
-        SELECT ?resource ?sameAs
+        SELECT ?tool ?resourceId
         WHERE {
-            ?resource a nf:Tool ;
-                      owl:sameAs ?sameAs .
+            ?tool nf:resourceId ?resourceId .
+            FILTER(!CONTAINS(STR(?tool), "resource/"))
         }
         """
-        results = list(resources_graph.query(query, initNs={"nf": NF, "owl": OWL}))
-        assert len(results) > 0, "No owl:sameAs relationships found"
+        results = list(resources_graph.query(query, initNs={"nf": NF}))
+        assert len(results) > 0, "No resourceId properties found on tool-specific subjects"
 
-    def test_owl_sameas_to_cell_line_id(self, resources_graph, namespaces):
-        """Resources should link to cellLineId via owl:sameAs"""
-        # Just verify some owl:sameAs relationships exist
-        query = """
-        SELECT ?resource ?sameAs
-        WHERE {
-            ?resource owl:sameAs ?sameAs .
-            FILTER(CONTAINS(STR(?sameAs), "e77e65be"))
-        }
-        """
-        results = list(resources_graph.query(query, initNs={"owl": OWL}))
-        # Test passes if there are any owl:sameAs relationships, even if specific IDs vary
-        assert len(resources_graph.query("SELECT ?s ?o WHERE { ?s owl:sameAs ?o }", initNs={"owl": OWL})) > 0, \
-            "Expected some owl:sameAs relationships"
+    def test_resource_id_is_string_literal(self, resources_graph, namespaces):
+        """resourceId should be a string literal, not an IRI"""
+        NF = namespaces["nf"]
 
-    def test_sameas_targets_are_iris(self, resources_graph):
-        """owl:sameAs targets should be IRIs"""
         query = """
-        SELECT ?resource ?sameAs
+        SELECT ?tool ?resourceId
         WHERE {
-            ?resource owl:sameAs ?sameAs .
+            ?tool nf:resourceId ?resourceId .
         }
         """
-        results = list(resources_graph.query(query, initNs={"owl": OWL}))
+        results = list(resources_graph.query(query, initNs={"nf": NF}))
 
         for row in results:
-            assert isinstance(row.sameAs, URIRef), \
-                f"owl:sameAs target should be IRI, got {type(row.sameAs)}"
+            assert isinstance(row.resourceId, Literal), \
+                f"resourceId should be Literal, got {type(row.resourceId)}"
+
+    def test_no_owl_sameas(self, resources_graph):
+        """Graph should not contain any owl:sameAs triples"""
+        from rdflib.namespace import OWL
+        results = list(resources_graph.query(
+            "SELECT ?s ?o WHERE { ?s owl:sameAs ?o }",
+            initNs={"owl": OWL}
+        ))
+        assert len(results) == 0, \
+            f"Expected no owl:sameAs triples, found {len(results)}"
 
 
 class TestResourcesMultiValueFields:
@@ -261,17 +258,20 @@ class TestResourcesEmptyFields:
 class TestResourcesDataQuality:
     """Test data quality and consistency"""
 
-    def test_all_resources_have_resource_id(self, resources_graph, namespaces):
-        """All Tool entities should have a resourceId in their IRI"""
+    def test_all_resources_use_tool_specific_iris(self, resources_graph, namespaces):
+        """All Tool entities should use tool-specific IRIs, not generic resource/ IRIs"""
         NF = namespaces["nf"]
+        tool_prefixes = ("cellLine/", "antibody/", "animalModel/", "geneticReagent/", "biobank/")
 
         tools = list(resources_graph.subjects(RDF.type, NF.Tool))
+        assert len(tools) > 0, "No tools found"
 
         for tool in tools:
             tool_str = str(tool)
-            # Should be a valid UUID-like ID
-            assert len(tool_str.split('/')[-1]) > 10, \
-                f"Resource IRI should contain resourceId: {tool_str}"
+            assert any(p in tool_str for p in tool_prefixes), \
+                f"Expected tool-specific IRI, got: {tool_str}"
+            assert "resource/" not in tool_str, \
+                f"Should not use generic resource/ IRI: {tool_str}"
 
     def test_dates_are_present(self, resources_graph, namespaces):
         """Resources should have date fields"""


### PR DESCRIPTION
Performance optimization to remove `owl:sameAs` usage, which is expensive though initially convenient given that resources use both resource ID and tool-specific ids.