### PR TITLE
Update semantic evals

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -131,7 +131,7 @@ Important item characteristics:
 
 ### Files
 
-- **`main/eval_tools.yaml`**: Question definitions and metadata (stats below)
+- **`main/dataset_attributes.yaml`**: Question definitions and metadata (stats below)
 - **`main/eval_tools_ground_auto.yaml`**: Automatically generated ground truth
 - **`main/eval_tools_ground_manual.yaml`**: Manually curated ground truth
 - **`main/generate_ground_truth.py`**: Ground truth generation script
@@ -156,7 +156,7 @@ There is only one question that returns a number (count) instead of uuid(s).
 
 ### Data Versioning
 
-**Dataset Version**: v1
+**Dataset Version**: v1.1
 
 Data archived at **syn73695746**
 
@@ -164,21 +164,21 @@ Data archived at **syn73695746**
 
 ### Dataset Statistics
 
-- **Total Questions**: 34
-  - Complete: 34
+- **Total Questions**: 35
+  - Complete: 35
   - Incomplete/WIP: 0
 
 #### By Complexity
 - **0-hop**: 14
-- **1-hop**: 14
+- **1-hop**: 15
 - **2-hop**: 6
 
 #### By Difficulty Level
-- **advanced**: 17
+- **advanced**: 18
 - **baseline**: 17
 
 #### By Persona
-- **Researcher**: 28
+- **Researcher**: 29
 - **Gene Therapy Developer**: 4
 - **Bioinformatician**: 1
 - **Program Officer**: 1
@@ -186,7 +186,7 @@ Data archived at **syn73695746**
 *Total unique personas: 4*
 
 #### By Demo Priority
-- **high**: 14
+- **high**: 15
 - **medium**: 13
 - **low**: 7
 
@@ -194,13 +194,13 @@ Data archived at **syn73695746**
 
 | Technology | Yes | Partial | No |
 |------------|-----|---------|-----|
-| **Facet Filters** | 9 | 3 | 22 |
-| **Text Search** | 13 | 8 | 13 |
+| **Facet Filters** | 9 | 3 | 23 |
+| **Text Search** | 13 | 8 | 14 |
 
 #### Ground Truth Availability
 
-- **Automated** (generated from CSV data): 32
-- **Manual** (curated, requires interpretation): 2
+- **Automated** (generated from CSV data): 31
+- **Manual** (curated, requires interpretation): 4
 
 ---
 
@@ -228,7 +228,7 @@ Data archived at **syn73695746**
 
 | ID | Question | Level | Complexity | Facet | Text Search |
 |----|----------|-------|------------|-------|-------------|
-| AM-001 | What animal models are available for optic glioma? | baseline | 0-hop | Yes | Yes |
+| AM-001 | I want animal models to study optic glioma | baseline | 0-hop | Yes | Yes |
 | AM-002 | Help me find animal models suitable for energy expenditure studies | baseline | 0-hop | Partial | Partial |
 | AM-003 | Are there any non-mouse mammalian models available? | baseline | 0-hop | Yes | Partial |
 | AM-004 | Which mouse model has the earliest observed tumor development? | advanced | 1-hop | No | No |
@@ -245,7 +245,7 @@ Data archived at **syn73695746**
 |----|----------|-------|------------|-------|-------------|
 | CL-001 | Show me plexiform neurofibroma cell lines | baseline | 0-hop | Yes | Yes |
 | CL-002 | What hybridoma cell lines are available? | baseline | 0-hop | Yes | Yes |
-| CL-003 | Find normal schwann cell lines | baseline | 1-hop | Partial | Yes |
+| CL-003 | I need normal schwann cell lines | baseline | 1-hop | Partial | Yes |
 | CL-004 | Find NF1 cell lines from black patients | baseline | 0-hop | Yes | Partial |
 | CL-005 | Find human cell lines from pediatric donors | baseline | 1-hop | Partial | No |
 | CL-006 | Find human lung cell lines for pulmonary toxicity assessment | baseline | 0-hop | No | Yes |
@@ -263,7 +263,7 @@ Data archived at **syn73695746**
 |----|----------|-------|------------|-------|-------------|
 | AB-001 | Find drosophila neurofibromin antibodies | baseline | 0-hop | Yes | Yes |
 | AB-002 | Find antibodies targeting the C-terminal region of neurofibromin | baseline | 0-hop | No | Yes |
-| AB-003 | Find antibodies for studying NF1 phosphorylation and post-translational regul... | advanced | 1-hop | No | Partial |
+| AB-003 | Give me antibodies for studying NF1 phosphorylation and post-translational re... | advanced | 1-hop | No | Partial |
 
 
 #### Genetic Reagent Discovery
@@ -273,8 +273,8 @@ Data archived at **syn73695746**
 
 | ID | Question | Level | Complexity | Facet | Text Search |
 |----|----------|-------|------------|-------|-------------|
-| GR-001 | Find CRISPR vectors | baseline | 0-hop | Yes | Yes |
-| GR-002 | Find lentiviral vectors for RNAi | baseline | 0-hop | Yes | Yes |
+| GR-001 | Need CRISPR vectors | baseline | 0-hop | Yes | Yes |
+| GR-002 | Need lentiviral vectors for RNAi | baseline | 0-hop | Yes | Yes |
 | GR-003 | Find vectors with a CMV promoter | baseline | 0-hop | No | Yes |
 | GR-004 | Find NF1 expression vectors compatible with high-copy E. coli systems | advanced | 1-hop | No | Partial |
 | GR-005 | Find vectors with resistance markers suitable for mammalian selection | advanced | 1-hop | No | No |
@@ -287,20 +287,21 @@ Data archived at **syn73695746**
 
 | ID | Question | Level | Complexity | Facet | Text Search |
 |----|----------|-------|------------|-------|-------------|
-| PI-001 | Find tools developed by Piotr Topilko | baseline | 1-hop | Yes | Yes |
+| PI-001 | What tools have been developed by Piotr Topilko | baseline | 1-hop | Yes | Yes |
 | PI-002 | How many tools have been funded by GFF? | advanced | 2-hop | No | No |
 
 
 #### Integrated Resource Queries
 *Questions that integrate data across multiple resource types or with additional semantics*
 
-**Questions: 3/3 complete**
+**Questions: 4/4 complete**
 
 | ID | Question | Level | Complexity | Facet | Text Search |
 |----|----------|-------|------------|-------|-------------|
 | CR-001 | Which cell lines have shown sensitivity to HDAC inhibitors? | advanced | 1-hop | No | Partial |
 | CR-002 | Find human cell lines with the most diverse data types available on the portal. | advanced | 2-hop | No | No |
 | CR-003 | Find animal models and cell lines that are derived from the same donor | advanced | 2-hop | No | No |
+| CR-004 | I want to acquire the SZ-NF1 cell line. Does it require a Materials Transfer ... | advanced | 1-hop | No | No |
 
 
 ---

--- a/evaluation/generate_eval_tools_readme.py
+++ b/evaluation/generate_eval_tools_readme.py
@@ -493,6 +493,10 @@ def main():
     print(f"Updating {readme_path}...")
     final_content = update_readme_section(readme_path, readme_content)
 
+    # Write main section update first so QA stats can read it back
+    with open(readme_path, 'w') as f:
+        f.write(final_content)
+
     # Generate and update QA stats
     print("Generating QA statistics...")
     qa_stats = generate_qa_stats(qa_dir)
@@ -500,11 +504,10 @@ def main():
         qa_stats_md = format_qa_stats_markdown(qa_stats)
         final_content = update_qa_stats_in_readme(readme_path, qa_stats_md)
         print(f"  QA: {qa_stats['total_papers']} papers, {qa_stats['total_questions']} questions")
+        with open(readme_path, 'w') as f:
+            f.write(final_content)
     else:
         print("  No QA files found, skipping QA stats")
-
-    with open(readme_path, 'w') as f:
-        f.write(final_content)
 
     print("✓ README updated successfully!")
     print(f"  Main: {stats['total']} questions ({stats['complete']} complete, {stats['incomplete']} incomplete)")

--- a/evaluation/main/CHANGELOG.md
+++ b/evaluation/main/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the NF Research Tools Discovery evaluation dataset will be documented in this file.
 
+## [v1.1] - 2026-04-17
+
+### Added
+- **CR-004**: MTA (Materials Transfer Agreement) question for SZ-NF1 cell line — tests agent calibration and hallucination resistance with multiple-choice format
+- Scorer support for non-UUID free-text answers (phrase containment matching)
+- `scripts/quick_eval.py` for running targeted evaluations on individual questions
+
+### Changed
+- **CL-003**: Corrected ground truth from 1 result (YST-1, a miscategorized schwannoma) to 4 normal Schwann cell lines (hTERT SC ipn97.4, hTERT ipn02.3 2λ, hTERT ipn02.8, ScienCell Schwann cells)
+- `generate_ground_truth.py`: Switched question source from removed `eval_tools.yaml` to `dataset_attributes.yaml`; CL-003 now searches name/description/synonyms via resources join and excludes schwannoma and NF1 knockout lines
+- `nf_rag/task.py`: `task_filter` and `task_category` now accept both string and list inputs
+
+### Ground truth corrections (from PR #47)
+- **AM-001**: Added description search for 'optic glioma' instead of only matching on manifestation property, catching 2 additional models
+- **CL-004**: Added NF1 filter + fixed race column handling after join suffix changes, excludes 3 non-NF1 KRAS-mutant lung lines from Black donors
+- **CL-005**: Correctly excludes 2 canine cell lines with pediatric-age donors; simplified species column reference
+- **CL-006**: Same species column cleanup as CL-005, no changes to answer set
+- **CL-008**: Rewrote isogenic pair logic — builds donor families via parentDonorId chains, requires exactly 1 total mutation (must be NF1), matching tissue/organ/category, and a 0-mutation wildtype counterpart in the same family. Reduced from 50 to 10 results.
+
+### Dataset Overview
+- **Total Questions:** 35 (31 automated + 4 manual)
+- **Question Categories:** CR now has 4 questions (was 3)
+- **Manual ground truth:** AM-004, CL-003, CR-001, CR-004 (was AM-004, CR-001)
+
 ## [v1] - 2026-02-12
 
 ### Notes

--- a/evaluation/main/dataset_attributes.yaml
+++ b/evaluation/main/dataset_attributes.yaml
@@ -540,3 +540,15 @@ components:
         user_frustration: very_high
         demo_priority: high
         demo_rationale: "Cross-resource matching, donor-based integration"
+
+      - id: CR-004
+        question: "I want to acquire the SZ-NF1 cell line. Does it require a Materials Transfer Agreement (MTA)? Return the exact phrasing of your choice: (A) Yes (B) No (C) Not explicitly documented but likely (D) Not explicitly documented so unlikely"
+        user_story: "As a researcher planning to acquire the SZ-NF1 cell line, I want to know whether I need to arrange an MTA before requesting materials"
+        level: advanced
+        complexity: 1-hop
+        facet_answerable: no
+        text_search_answerable: no
+        user_frustration: moderate
+        note: "Tests agent calibration on a specific cell line. SZ-NF1 has documented restrictions (IRB required, non-commercial use only, no chimeras, etc.) but no explicit MTA mention. The ontology notes MTAs are standard practice and absence of documentation should not be interpreted as not required. The agent must check usageRequirements, find no MTA, but recognize from other restrictions and ontology guidance that an MTA is likely."
+        demo_priority: high
+        demo_rationale: "Common practical question for material acquisition; tests overconfidence and hallucination"

--- a/evaluation/main/dataset_attributes.yaml
+++ b/evaluation/main/dataset_attributes.yaml
@@ -59,7 +59,7 @@
 #   ✓ Can be explained clearly in <30 seconds
 
 metadata:
-  version: v1
+  version: v1.1
   data_archive: syn73695746
 
 components:

--- a/evaluation/main/dataset_attributes.yaml
+++ b/evaluation/main/dataset_attributes.yaml
@@ -275,7 +275,7 @@ components:
         text_search_answerable: yes
         text_search_note: "Resource Type = 'Cell Line' + 'Cell Line Genetic Disorder' = 'No known genetic disorder' + 'schwann' in text search; relevant hits at bottom"
         user_frustration: moderate
-        note: Text search returns healthy cell lines at very bottom bc affected cell lines are incorrectly categorized w/ 'No known genetic disorder'; issues with data rather than search capability
+        note: "Not all Schwann cell lines have 'schwann' in their name — some use the abbreviation 'SC' (e.g. hTERT SC ipn02.3) only in synonyms, requiring synonym or description search to find them. Additionally, schwannoma (tumor) lines and NF1 -/- knockouts are miscategorized with 'No known genetic disorder', so naive filtering on that field alone returns false positives."
         demo_priority: medium
         demo_rationale: "Control lines for experiments, common need"
 

--- a/evaluation/main/eval_tools_ground_auto.yaml
+++ b/evaluation/main/eval_tools_ground_auto.yaml
@@ -1,10 +1,11 @@
 metadata:
-  generated_at: '2026-04-16T18:04:48.704181'
+  generated_at: '2026-04-17T10:58:20.001669'
   skipped_questions:
   - AM-004
   - CL-003
   - CR-001
-  total_questions: 34
+  - CR-004
+  total_questions: 35
   generated_questions: 31
 ground_truth:
   AB-001:

--- a/evaluation/main/eval_tools_ground_auto.yaml
+++ b/evaluation/main/eval_tools_ground_auto.yaml
@@ -1,10 +1,11 @@
 metadata:
-  generated_at: '2026-04-16T09:58:19.165195'
+  generated_at: '2026-04-16T18:04:48.704181'
   skipped_questions:
   - AM-004
+  - CL-003
   - CR-001
   total_questions: 34
-  generated_questions: 32
+  generated_questions: 31
 ground_truth:
   AB-001:
     question: Find drosophila neurofibromin antibodies
@@ -80,10 +81,6 @@ ground_truth:
     - 42257ac4-1950-4541-9bee-b9a965e2fa86
     - 65d07476-2469-4679-85b2-e2ca67f3b01b
     - f410431d-7571-4302-8870-eb115b71d0ce
-  CL-003:
-    question: I need normal schwann cell lines
-    results:
-    - 617cb183-3377-4473-8ad8-2f6472bce1fa
   CL-004:
     question: Find NF1 cell lines from black patients
     results:

--- a/evaluation/main/eval_tools_ground_manual.yaml
+++ b/evaluation/main/eval_tools_ground_manual.yaml
@@ -7,6 +7,7 @@ metadata:
   description: "Manually curated ground truth for complex evaluation questions"
   manually_maintained_questions:
     - AM-004
+    - CL-003
     - CR-001
 
 ground_truth:
@@ -49,6 +50,42 @@ ground_truth:
     notes: >
       Advanced question bc the Observations text needs to be interpeted for actually relevant results. 
       Models found after Observations data review have actual tumor detection at 120 days (4 months).
+
+  CL-003:
+    question: "I need normal schwann cell lines"
+    results:
+      - 13ae2445-21e3-4b75-ae70-317a3d5ee40c  # hTERT SC ipn97.4
+      - 3a507bfd-7d2b-4238-b79a-83fe985c2cea  # hTERT ipn02.3 2λ
+      - 3a8f5be4-aa22-48f2-9a76-9412010ecd45  # hTERT ipn02.8
+      - b751b5d4-56e6-42a2-a2dc-289f90c6dd82  # ScienCell Schwann cells
+
+    methodology: |
+      "Normal" Schwann cell lines must satisfy all of:
+      1. Identified as Schwann cells via name, description, or synonyms
+         (includes "schwann" or the abbreviation "hTERT SC" = Schwann Cell)
+      2. geneticDisorder = "No known genetic disorder"
+      3. Not a schwannoma (tumor-derived) line
+      4. Not an NF1 knockout or engineered mutant (e.g. NF1 -/-)
+      5. Cell line category consistent with "normal" — finite or telomerase
+         immortalized lines qualify; cancer, transformed, iPSC, embryonic stem,
+         hybridoma, hybrid, and spontaneously immortalized lines do not
+
+    notes: |
+      Several lines are miscategorized with "No known genetic disorder" in source data.
+      Recommended corrections:
+      - 617cb183-3377-4473-8ad8-2f6472bce1fa (YST-1, cellLineId 4379c5e8-34d5-43f2-b0a8-2711c513eb40):
+        schwannoma tumor line; should be "Schwannomatosis"
+      - 234515dd-7c28-4172-83c7-59dddfa22acb (Schwann cell NF1 -/- iPN97.4 #24, cellLineId 859f3f11-7be4-41c1-97aa-05e86f0c8202):
+        NF1 knockout; should be "Neurofibromatosis type 1"
+      - faf29a50-3168-4ccd-a484-f2a78a026af3 (Schwann cell NF1 -/- with R681X mNf1 cDNA, cellLineId be5c41c4-e9ae-4330-a48b-7b81d26a0c91):
+        NF1 knockout + rescue; should be "Neurofibromatosis type 1"
+      - 3a3e5460-3d5b-45f9-995d-25bd49c06f34 (Schwann cell NF1 -/- with R816X mNf1 cDNA, cellLineId 766629ea-794c-4678-838d-4309d1e825e2):
+        NF1 knockout + rescue; should be "Neurofibromatosis type 1"
+      - 3beebac1-95b0-4834-9008-19f7d268fc5b (Schwann cell NF1 -/- with WT tagged mNf1 cDNA, cellLineId 36050621-0007-4b26-afec-08d43675afc4):
+        NF1 knockout + rescue; should be "Neurofibromatosis type 1"
+
+      Some Schwann cell lines use the abbreviation "SC" only in synonyms
+      (e.g. "hTERT SC ipn02.3 2lambda"), requiring synonym search to discover.
 
   CR-001:
     question: "Which cell lines have shown sensitivity to HDAC inhibitors?"

--- a/evaluation/main/eval_tools_ground_manual.yaml
+++ b/evaluation/main/eval_tools_ground_manual.yaml
@@ -9,6 +9,7 @@ metadata:
     - AM-004
     - CL-003
     - CR-001
+    - CR-004
 
 ground_truth:
   AM-004:
@@ -86,6 +87,31 @@ ground_truth:
 
       Some Schwann cell lines use the abbreviation "SC" only in synonyms
       (e.g. "hTERT SC ipn02.3 2lambda"), requiring synonym search to discover.
+
+  CR-004:
+    question: "Does the SZ-NF1 cell line require MTA? Please answer exactly: 'Yes', 'No', 'Not explicitly documented but likely', or 'Not explicitly documented so unlikely'"
+    results:
+      - "Not explicitly documented but likely"
+
+    methodology: |
+      1. Find SZ-NF1 in the graph and check its usageRequirements — has IRB
+         documentation required, non-commercial use only, no chimeras, etc.
+         but no explicit MTA mention
+      2. Check howToAcquire — contact the originating investigator, which
+         strongly implies a formal transfer process
+      3. Consult the ontology: MaterialsTransferAgreement class states that
+         MTAs are standard practice and absence of explicit mention should
+         not be interpreted as MTA not being required
+      4. Correct answer acknowledges the data gap without overconfident assertion
+
+    notes: |
+      This question tests agent calibration and hallucination resistance.
+      - An overconfident agent may answer "Yes" without evidence in the data
+      - A naive agent may answer "No" because usageRequirements doesn't mention MTA
+      - A well-calibrated agent checks SZ-NF1's restrictions, sees the heavy
+        usage constraints and investigator-contact acquisition model, reads
+        the ontology guidance, and correctly hedges with "Not explicitly
+        documented but likely"
 
   CR-001:
     question: "Which cell lines have shown sensitivity to HDAC inhibitors?"

--- a/evaluation/main/generate_ground_truth.py
+++ b/evaluation/main/generate_ground_truth.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 # Path adjusted for script location in evaluation/main/
 DATA_DIR = '../data/csv'
-EVAL_TOOLS_FILE = 'eval_tools.yaml'
+DATASET_ATTRIBUTES_FILE = 'dataset_attributes.yaml'
 OUTPUT_FILE = 'eval_tools_ground_auto.yaml'
 
 def load_data():
@@ -47,11 +47,11 @@ def load_data():
     return data
 
 def get_all_questions():
-    if not os.path.exists(EVAL_TOOLS_FILE):
+    if not os.path.exists(DATASET_ATTRIBUTES_FILE):
         return {}
-    with open(EVAL_TOOLS_FILE, 'r') as f:
+    with open(DATASET_ATTRIBUTES_FILE, 'r') as f:
         config = yaml.safe_load(f)
-    
+
     questions = {}
     for component in config.get('components', []):
         for q in component.get('questions', []):
@@ -305,20 +305,9 @@ def run_queries(data):
         matches = df[df['cellLineCategory'].str.contains('Hybridoma', case=False, na=False)]
         results['CL-002'] = ensure_resource_id(matches['cellLineId'].tolist())
 
-    # CL-003: normal schwann cell lines
-    if not data['cell_lines'].empty:
-        df = data['cell_lines']
-        matches = df[
-            (df['cellLineGeneticDisorder'].str.contains('No known genetic disorder', case=False, na=False)) &
-            (df['tissue'].str.contains('schwann', case=False, na=False) | 
-             df['cellLineManifestation'].str.contains('schwann', case=False, na=False))
-        ]
-        if matches.empty:
-            matches = df[
-                (df['cellLineGeneticDisorder'].str.contains('No known genetic disorder', case=False, na=False)) &
-                (df.apply(lambda row: row.astype(str).str.contains('schwann', case=False).any(), axis=1))
-            ]
-        results['CL-003'] = ensure_resource_id(matches['cellLineId'].tolist())
+    # CL-003: Moved to eval_tools_ground_manual.yaml — defining "normal" requires
+    # excluding schwannoma, NF1 knockouts, and certain cell line categories (cancer,
+    # transformed, iPSC, etc.) which is better handled by manual curation.
 
     # CL-004: Black patients
     if not cells_donors_resources.empty:

--- a/schema/ontology.ttl
+++ b/schema/ontology.ttl
@@ -237,6 +237,13 @@ nf:CellLine a owl:Class ;
     rdfs:label "Cell Line" ;
     rdfs:comment "A cell line used in research. Cell lines can be filtered by race and may participate in donor-matching links via sharedDonor." .
 
+nf:NormalCellLine a owl:Class ;
+    rdfs:subClassOf nf:CellLine ;
+    owl:equivalentClass efo:EFO_0002922 ;
+    owl:unionOf ( nf:FiniteCellLine nf:TelomeraseImmortalizedCellLine ) ;
+    rdfs:label "Normal Cell Line" ;
+    rdfs:comment "A cell line derived from non-diseased tissue that retains key characteristics of normal cells: finite lifespan, genetic stability (normal diploid karyotype), regulated growth, and typical functional characteristics. In experimental contexts, normal cell lines serve as controls or baselines representing the unperturbed biological state" .
+
 nf:CancerCellLine a owl:Class ;
     rdfs:subClassOf nf:CellLine ;
     owl:equivalentClass efo:EFO_0001639 ;

--- a/schema/ontology.ttl
+++ b/schema/ontology.ttl
@@ -390,6 +390,10 @@ nf:DerivationObservation a owl:Class ;
     rdfs:label "Derivation observation" ;
     rdfs:comment "An observation describing the origin, lineage, or creation method of a resource, such as cell line derivation, immortalization, or tissue of origin" .
 
+nf:MaterialsTransferAgreement a owl:Class ;
+    rdfs:label "Materials Transfer Agreement" ;
+    rdfs:comment "A legal agreement governing the transfer of research materials between organizations. Whether a resource requires an MTA can be inferred from the usageRequirements property containing 'MTA' or 'Materials Transfer Agreement'." .
+
 nf:IssueObservation a owl:Class ;
     rdfs:subClassOf nf:Observation ;
     rdfs:label "Issue observation" ;
@@ -1070,7 +1074,7 @@ nf:specimenTissueType a owl:DatatypeProperty ;
 # Shared properties
 nf:geneticDisorder a owl:DatatypeProperty ;
     rdfs:label "geneticDisorder" ;
-    rdfs:comment "Genetic disorder associated with the resource." ;
+    rdfs:comment "Genetic disorder associated with the resource. A value of 'No known genetic disorder' indicates a normal, healthy, or control resource with no disease association. When users ask for 'normal' cell lines or animal models, this is the distinguishing attribute." ;
     rdfs:range xsd:string .
 
 nf:organ a owl:DatatypeProperty ;
@@ -1083,7 +1087,7 @@ nf:rrid a owl:ObjectProperty ;
 
 nf:usageRequirements a owl:DatatypeProperty ;
     rdfs:label "usageRequirements" ;
-    rdfs:comment "Requirements or restrictions for using a resource." ;
+    rdfs:comment "Requirements or restrictions for using a resource. May include terms such as 'MTA' or 'Materials Transfer Agreement', indicating that a legal agreement is required before the resource can be transferred to the requesting party." ;
     rdfs:range xsd:string .
 
 nf:synonyms a owl:DatatypeProperty ;

--- a/schema/ontology.ttl
+++ b/schema/ontology.ttl
@@ -399,7 +399,7 @@ nf:DerivationObservation a owl:Class ;
 
 nf:MaterialsTransferAgreement a owl:Class ;
     rdfs:label "Materials Transfer Agreement" ;
-    rdfs:comment "A legal agreement governing the transfer of research materials between organizations. Whether a resource requires an MTA can be inferred from the usageRequirements property containing 'MTA' or 'Materials Transfer Agreement'." .
+    rdfs:comment "A legal agreement governing the transfer of research materials between organizations. MTAs are standard practice in academic and commercial sharing of biological materials such as cell lines, animal models, and genetic reagents. In practice, most providers require an MTA by default even when not explicitly documented. Whether a specific resource explicitly requires an MTA can be checked via the usageRequirements property, but absence of an explicit mention should not be interpreted as MTA not being required. The howToAcquire property may also provide clues: when acquisition requires contacting an originating investigator directly, an MTA is typically involved." .
 
 nf:IssueObservation a owl:Class ;
     rdfs:subClassOf nf:Observation ;

--- a/schema/ontology.ttl
+++ b/schema/ontology.ttl
@@ -1094,7 +1094,7 @@ nf:rrid a owl:ObjectProperty ;
 
 nf:usageRequirements a owl:DatatypeProperty ;
     rdfs:label "usageRequirements" ;
-    rdfs:comment "Requirements or restrictions for using a resource. May include terms such as 'MTA' or 'Materials Transfer Agreement', indicating that a legal agreement is required before the resource can be transferred to the requesting party." ;
+    rdfs:comment "Requirements or restrictions for using a resource. May include terms such as 'MTA' or 'Materials Transfer Agreement', indicating that a legal agreement is required before the resource can be transferred to the requesting party. Note that the absence of an explicit MTA mention does not guarantee that no MTA is required; some providers require MTAs by default and this may not be recorded in the data." ;
     rdfs:range xsd:string .
 
 nf:synonyms a owl:DatatypeProperty ;


### PR DESCRIPTION
Address #46 by adding more MTA-related knowledge to ontology and adding MTA eval question. Partially address #48, which investigated surprisingly low performance for CL-003. Upstream data being revised so moved ground truth to manual maintenance instead of auto-generation. To help with future reasoning, also added normal cell line class directly mapping to [EFO:0002922](http://www.ebi.ac.uk/efo/EFO_0002922) and applicable constraints. Update eval dataset version and changelog.