### PR TITLE
Add node embeddings pipeline

### DIFF
--- a/.github/workflows/publish-embeddings.yml
+++ b/.github/workflows/publish-embeddings.yml
@@ -1,0 +1,113 @@
+# Generate and publish node embeddings from a completed graph build.
+#
+# Triggered manually — intended for releases where embeddings are wanted alongside
+# the RDF. Point it at any successful build-image run via build_run_id.
+#
+# Outputs kg.edgelist and kg.emd, archived to Synapse under
+# data_sources.yaml profiles.release.embeddings_archive.folder_id.
+#
+# Runtime note: GitHub-hosted runners have 2 vCPUs. Embedding generation
+# takes ~7 min on 16 cores; expect ~30-40 min on 2 cores.
+# Use a larger self-hosted runner for faster turnaround if available.
+
+name: Publish embeddings
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_run_id:
+        description: "Run ID of the build-image workflow to generate embeddings from"
+        required: true
+        type: string
+      comment:
+        description: "Comment for the Synapse archive entry"
+        required: false
+        default: ""
+        type: string
+
+env:
+  PECANPY_WORKERS: 2
+
+jobs:
+  embeddings:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pecanpy pyoxigraph synapseclient pyyaml
+
+      - name: Download RDF artifacts from build
+        uses: actions/download-artifact@v7
+        with:
+          name: kg-data
+          path: .
+          run-id: ${{ inputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate edgelist
+        run: make edgelist
+
+      - name: Generate embeddings
+        run: make embeddings PECANPY_WORKERS=${{ env.PECANPY_WORKERS }}
+
+      - name: Archive edgelist and embeddings to Synapse
+        env:
+          SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
+        run: |
+          python - <<'EOF'
+          import synapseclient, yaml, datetime
+
+          with open("data_sources.yaml") as f:
+              config = yaml.safe_load(f)
+
+          archive = config["profiles"]["release"].setdefault("embeddings_archive", {})
+          folder_id = archive.get("folder_id")
+          if not folder_id:
+              raise SystemExit("embeddings_archive.folder_id not set in data_sources.yaml")
+
+          syn = synapseclient.Synapse()
+          syn.login(authToken="${{ secrets.SYNAPSE_AUTH_TOKEN }}", silent=True)
+
+          comment = "${{ inputs.comment }}" or f"Embeddings from build run ${{ inputs.build_run_id }}"
+          now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+          for filename, key in [
+              ("data/embeddings/kg.edgelist", "edgelist_archive_id"),
+              ("data/embeddings/kg.emd",      "emd_archive_id"),
+          ]:
+              entity_id = archive.get(key)
+              if entity_id:
+                  f = synapseclient.File(filename, parent=folder_id, id=entity_id)
+              else:
+                  f = synapseclient.File(filename, parent=folder_id)
+              stored = syn.store(f, comment=comment)
+              archive[key] = stored.id
+              archive[f"{key.replace('_id', '_version')}"] = stored.versionNumber
+
+          archive["last_snapshot_comment"] = comment
+          archive["last_snapshot_date"] = now
+
+          with open("data_sources.yaml", "w") as f:
+              yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+          print(f"Archived edgelist: {archive['edgelist_archive_id']}")
+          print(f"Archived embeddings: {archive['emd_archive_id']}")
+          EOF
+
+      - name: Commit updated data_sources.yaml
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data_sources.yaml
+          git diff --staged --quiet || git commit -m "chore: update embeddings archive version [skip ci]"
+          git push origin HEAD:${{ github.ref_name }}

--- a/.github/workflows/publish-embeddings.yml
+++ b/.github/workflows/publish-embeddings.yml
@@ -90,7 +90,7 @@ jobs:
                   f = synapseclient.File(filename, parent=folder_id, id=entity_id)
               else:
                   f = synapseclient.File(filename, parent=folder_id)
-              stored = syn.store(f, comment=comment)
+              stored = syn.store(f)
               archive[key] = stored.id
               archive[f"{key.replace('_id', '_version')}"] = stored.versionNumber
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,8 @@ data/
 tmp/
 
 # Node embeddings — generated artifacts, not tracked
-# data/embeddings/kg.edgelist, data/embeddings/kg.emd, and data/embeddings/chroma/
-# are excluded by data/ above.
-# Regenerate with: make edgelist && make embeddings && make index
+# data/embeddings/kg.edgelist and data/embeddings/kg.emd are excluded by data/ above.
+# Regenerate with: make edgelist && make embeddings
 
 # Ignore RMLMapper logs
 logs/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 data/
 tmp/
 
+# Node embeddings — generated artifacts, not tracked
+# data/embeddings/kg.edgelist, data/embeddings/kg.emd, and data/embeddings/chroma/
+# are excluded by data/ above.
+# Regenerate with: make edgelist && make embeddings && make index
+
 # Ignore RMLMapper logs
 logs/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# Node embedding pipeline for NF KG.
+# Prerequisites: pip install pecanpy
+
+PYTHON ?= python
+RDF_DIR := data/rdf
+LOG_DIR := logs
+EMBEDDINGS_DIR := data/embeddings
+EDGELIST := $(EMBEDDINGS_DIR)/kg.edgelist
+EMBEDDINGS := $(EMBEDDINGS_DIR)/kg.emd
+EDGELIST_SCRIPT := scripts/rdf_to_edgelist.py
+
+PECANPY_MODE ?= PreCompFirstOrder
+PECANPY_WORKERS ?= 16
+PECANPY_DIM ?= 128
+PECANPY_WALKLEN ?= 80
+PECANPY_NUMWALKS ?= 10
+PECANPY_P ?= 1
+PECANPY_Q ?= 1
+
+$(EDGELIST): $(EDGELIST_SCRIPT) $(wildcard $(RDF_DIR)/*.ttl)
+	@mkdir -p $(EMBEDDINGS_DIR) $(LOG_DIR)
+	@echo "Converting RDF to edgelist..."
+	@/usr/bin/time -f "  Time: %E elapsed, %U user, %S system" \
+		$(PYTHON) $(EDGELIST_SCRIPT) --rdf-dir $(RDF_DIR) --output $@ 2>&1
+	@echo "  Output: $@"
+
+edgelist: $(EDGELIST)
+
+$(EMBEDDINGS): $(EDGELIST)
+	@echo "Running PecanPy (mode=$(PECANPY_MODE), dim=$(PECANPY_DIM))..."
+	@/usr/bin/time -f "  Time: %E elapsed, %U user, %S system" \
+		pecanpy --input $< --output $@ \
+		--mode $(PECANPY_MODE) \
+		--workers $(PECANPY_WORKERS) \
+		--dimensions $(PECANPY_DIM) \
+		--walk-length $(PECANPY_WALKLEN) \
+		--num-walks $(PECANPY_NUMWALKS) \
+		--p $(PECANPY_P) \
+		--q $(PECANPY_Q) \
+		--weighted 2>&1
+	@echo "  Output: $@"
+
+embeddings: $(EMBEDDINGS)
+
+clean_embeddings:
+	rm -f $(EDGELIST) $(EMBEDDINGS)

--- a/Makefile
+++ b/Makefile
@@ -42,15 +42,5 @@ $(EMBEDDINGS): $(EDGELIST)
 
 embeddings: $(EMBEDDINGS)
 
-CHROMA_DB := data/embeddings/chroma
-INDEX_SCRIPT := apps/personalized_search/index_embeddings.py
-
-$(CHROMA_DB): $(INDEX_SCRIPT) $(EMBEDDINGS)
-	@echo "Building ChromaDB vector index..."
-	@$(PYTHON) $(INDEX_SCRIPT) --db $(CHROMA_DB) --embeddings $(EMBEDDINGS)
-
-index: $(CHROMA_DB)
-
 clean_embeddings:
 	rm -f $(EDGELIST) $(EMBEDDINGS)
-	rm -rf $(CHROMA_DB)

--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,15 @@ $(EMBEDDINGS): $(EDGELIST)
 
 embeddings: $(EMBEDDINGS)
 
+CHROMA_DB := data/embeddings/chroma
+INDEX_SCRIPT := apps/personalized_search/index_embeddings.py
+
+$(CHROMA_DB): $(INDEX_SCRIPT) $(EMBEDDINGS)
+	@echo "Building ChromaDB vector index..."
+	@$(PYTHON) $(INDEX_SCRIPT) --db $(CHROMA_DB) --embeddings $(EMBEDDINGS)
+
+index: $(CHROMA_DB)
+
 clean_embeddings:
 	rm -f $(EDGELIST) $(EMBEDDINGS)
+	rm -rf $(CHROMA_DB)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ scripts/
   diff_rdf.py                    Diff current build against previous Synapse archive
   rdf_to_edgelist.py             RDF -> weighted edgelist for node embeddings
   astabench.py                   Prepare eval data and run astabench across models
+apps/
+  personalized_search/           Node embedding-based personalized search (see README)
+docs/
+  node-embeddings.md             Embedding pipeline and ChromaDB index docs
 data/
   csv/                           Source and harmonized CSVs
   rdf/                           Generated RDF (Turtle)

--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ scripts/
   diff_rdf.py                    Diff current build against previous Synapse archive
   rdf_to_edgelist.py             RDF -> weighted edgelist for node embeddings
   astabench.py                   Prepare eval data and run astabench across models
-apps/
-  personalized_search/           Node embedding-based personalized search (see README)
 docs/
   node-embeddings.md             Embedding pipeline and ChromaDB index docs
 data/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ data/rdf/*.ttl                  RDF triples
       │
       ▼  derived RDF materialization (e.g. shared donor links)
 data/rdf/shared_donor_links.ttl derived RDF triples
+      │
+      ▼  scripts/rdf_to_edgelist.py
+data/embeddings/kg.edgelist     weighted IRI edgelist
+      │
+      ▼  PecanPy / node2vec
+data/embeddings/kg.emd          128-dim node embeddings
 ```
 
 **1. Extract** — `prepare_portal_tables.py` downloads tables via `synapseclient`,
@@ -48,6 +54,8 @@ using [`reasonable`](https://pypi.org/project/reasonable/) and adds
 `nf:sharedDonor` only when an animal model `transplantationDonorId` matches a
 cell line `donorId`.
 
+**5. Node Embeddings** — See [docs/node-embeddings.md](docs/node-embeddings.md).
+
 ### Project structure
 
 ```
@@ -62,11 +70,13 @@ scripts/
   validate_fks.py                CSV-level foreign key validation (see HARMONIZATION.md)
   archive_rdf.py                 Merge and upload RDF snapshot to Synapse
   diff_rdf.py                    Diff current build against previous Synapse archive
+  rdf_to_edgelist.py             RDF -> weighted edgelist for node embeddings
   astabench.py                   Prepare eval data and run astabench across models
 data/
   csv/                           Source and harmonized CSVs
   rdf/                           Generated RDF (Turtle)
   raw/                           Raw Synapse exports (cache)
+  embeddings/                    Edgelist and node embeddings
 orchestration/dagster_pipeline/  Dagster asset definitions for the full pipeline
 astabench/                       Eval framework (git submodule, see Evaluation)
 evaluation/                      Eval datasets for KG quality + RAG
@@ -182,3 +192,4 @@ Domain licenses; the derived corpus is distributed under
 
 - Java 21+ (RMLMapper 8.x)
 - Python 3.10+ with `rdflib`, `reasonable`, `synapseclient`, `pandas`
+- `pecanpy` (`pip install pecanpy`) for node embedding generation

--- a/data_sources.yaml
+++ b/data_sources.yaml
@@ -14,6 +14,14 @@ profiles:
       archive_version: null
       last_snapshot_comment: null
       last_snapshot_date: null
+    embeddings_archive:
+      folder_id: syn74760363
+      edgelist_archive_id: null
+      edgelist_archive_version: null
+      emd_archive_id: null
+      emd_archive_version: null
+      last_snapshot_comment: null
+      last_snapshot_date: null
     tables:
       studies:
         synapse_id: syn52694652

--- a/data_sources.yaml
+++ b/data_sources.yaml
@@ -16,12 +16,12 @@ profiles:
       last_snapshot_date: null
     embeddings_archive:
       folder_id: syn74760363
-      edgelist_archive_id: null
-      edgelist_archive_version: null
-      emd_archive_id: null
-      emd_archive_version: null
-      last_snapshot_comment: null
-      last_snapshot_date: null
+      edgelist_archive_id: syn74760478
+      edgelist_archive_version: 1
+      emd_archive_id: syn74760481
+      emd_archive_version: 1
+      last_snapshot_comment: Embeddings from node-embeddings branch (local test)
+      last_snapshot_date: 2026-04-30 00:42:51 UTC
     tables:
       studies:
         synapse_id: syn52694652

--- a/docs/node-embeddings.md
+++ b/docs/node-embeddings.md
@@ -2,8 +2,8 @@
 
 Node embeddings are generated from the KG RDF using
 [PecanPy](https://github.com/krishnanlab/PecanPy) (node2vec), producing low-dimensional vector
-representations of every entity in the graph. These are used for similarity search, discovery, and
-query suggestions.
+representations of every entity in the graph. These are used for similarity search, discovery,
+query suggestions, and other downstream applications.
 
 ### Overview
 
@@ -15,6 +15,9 @@ data/embeddings/kg.edgelist   ←── weighted IRI edgelist
       │
       ▼ (PecanPy / node2vec)
 data/embeddings/kg.emd        ←── 128-dim node embeddings
+      │
+      ▼ (index_embeddings.py)
+data/embeddings/chroma/       ←── ChromaDB vector index (type-filtered ANN search)
 ```
 
 ### Step 1: Edgelist extraction
@@ -61,9 +64,26 @@ Key parameters (all overridable on the command line):
 make embeddings PECANPY_NUMWALKS=5 PECANPY_WALKLEN=40
 ```
 
-### Usage
+### Step 3: ChromaDB vector index
 
-_To be documented._
+`apps/personalized_search/index_embeddings.py` indexes all 416k nodes into a persistent
+ChromaDB collection with entity-type metadata fetched from the SPARQL endpoint. This enables
+type-filtered ANN search without loading the full `.emd` file on each query.
+
+```bash
+make index   # Produces data/embeddings/chroma/ (requires qlever-rdf running)
+```
+
+**Type-filtered ANN search:** ChromaDB's HNSW index supports metadata filters at query time,
+so a search for "top-10 Studies nearest to this user vector" never touches the 408k File
+nodes — the filter is applied inside the index traversal, not as a post-filter over all
+results. This matters here because Files dominate the graph (98% of nodes); without filtering,
+a nearest-neighbor query would return almost exclusively files regardless of what the caller
+asked for. With the filter, each entity type gets its own fair ranking: the query
+`collection.query(query_embeddings=[vec], where={"type": "Study"}, n_results=10)` returns
+the 10 most similar Study nodes directly. As new entity types are added to the KG and
+embedded, they become queryable by type immediately without code changes — just pass a
+different `where` clause.
 
 ### References
 

--- a/docs/node-embeddings.md
+++ b/docs/node-embeddings.md
@@ -66,9 +66,9 @@ make embeddings PECANPY_NUMWALKS=5 PECANPY_WALKLEN=40
 
 ### Step 3: ChromaDB vector index
 
-`apps/personalized_search/index_embeddings.py` indexes all 416k nodes into a persistent
-ChromaDB collection with entity-type metadata fetched from the SPARQL endpoint. This enables
-type-filtered ANN search without loading the full `.emd` file on each query.
+`make index` builds a persistent ChromaDB collection from the `.emd` file, with entity-type
+metadata fetched from the SPARQL endpoint. This enables type-filtered ANN search without
+loading the full `.emd` file on each query.
 
 ```bash
 make index   # Produces data/embeddings/chroma/ (requires qlever-rdf running)

--- a/docs/node-embeddings.md
+++ b/docs/node-embeddings.md
@@ -1,0 +1,70 @@
+## Node embedding pipeline
+
+Node embeddings are generated from the KG RDF using
+[PecanPy](https://github.com/krishnanlab/PecanPy) (node2vec), producing low-dimensional vector
+representations of every entity in the graph. These are used for similarity search, discovery, and
+query suggestions.
+
+### Overview
+
+```
+data/rdf/*.ttl
+      │
+      ▼ (rdf_to_edgelist.py)
+data/embeddings/kg.edgelist   ←── weighted IRI edgelist
+      │
+      ▼ (PecanPy / node2vec)
+data/embeddings/kg.emd        ←── 128-dim node embeddings
+```
+
+### Step 1: Edgelist extraction
+
+`scripts/rdf_to_edgelist.py` loads all `.ttl` files from `data/rdf/` and extracts every triple
+where both subject and object are IRIs, producing a tab-separated weighted edgelist. Edge weight
+is the number of distinct predicates connecting each (subject, object) pair. Literal-object
+triples are skipped since literals are not graph nodes.
+
+```bash
+make edgelist   # Produces data/embeddings/kg.edgelist
+
+# Exclude rdf:type edges to focus on domain relations only
+python scripts/rdf_to_edgelist.py \
+  --exclude http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+```
+
+Current graph: ~893k edges across ~417k nodes (studies, files, investigators, tools, mutations,
+ontology terms, etc.).
+
+### Step 2: Node embeddings
+
+PecanPy [1] runs node2vec random walks over the edgelist and trains Word2Vec embeddings. Output is
+word2vec text format: one node IRI per line followed by 128 floats.
+
+```bash
+make embeddings   # Produces data/embeddings/kg.emd (~7 min on 16 cores)
+```
+
+Key parameters (all overridable on the command line):
+
+| Parameter | Default | Description |
+|---|---|---|
+| `PECANPY_MODE` | `PreCompFirstOrder` | Graph mode; use `SparseOTF` for very large graphs |
+| `PECANPY_DIM` | `128` | Embedding dimensions |
+| `PECANPY_WORKERS` | `16` | Parallel workers for Word2Vec training |
+| `PECANPY_WALKLEN` | `80` | Random walk length |
+| `PECANPY_NUMWALKS` | `10` | Walks per node |
+| `PECANPY_P` | `1` | Return parameter |
+| `PECANPY_Q` | `1` | In-out parameter |
+
+```bash
+# Example: faster run for experimentation
+make embeddings PECANPY_NUMWALKS=5 PECANPY_WALKLEN=40
+```
+
+### Usage
+
+_To be documented._
+
+### References
+
+1. PecanPy — GitHub: https://github.com/krishnanlab/PecanPy, Paper: https://doi.org/10.1093/bioinformatics/btab122

--- a/docs/node-embeddings.md
+++ b/docs/node-embeddings.md
@@ -15,9 +15,6 @@ data/embeddings/kg.edgelist   ←── weighted IRI edgelist
       │
       ▼ (PecanPy / node2vec)
 data/embeddings/kg.emd        ←── 128-dim node embeddings
-      │
-      ▼ (index_embeddings.py)
-data/embeddings/chroma/       ←── ChromaDB vector index (type-filtered ANN search)
 ```
 
 ### Step 1: Edgelist extraction
@@ -63,27 +60,6 @@ Key parameters (all overridable on the command line):
 # Example: faster run for experimentation
 make embeddings PECANPY_NUMWALKS=5 PECANPY_WALKLEN=40
 ```
-
-### Step 3: ChromaDB vector index
-
-`make index` builds a persistent ChromaDB collection from the `.emd` file, with entity-type
-metadata fetched from the SPARQL endpoint. This enables type-filtered ANN search without
-loading the full `.emd` file on each query.
-
-```bash
-make index   # Produces data/embeddings/chroma/ (requires qlever-rdf running)
-```
-
-**Type-filtered ANN search:** ChromaDB's HNSW index supports metadata filters at query time,
-so a search for "top-10 Studies nearest to this user vector" never touches the 408k File
-nodes — the filter is applied inside the index traversal, not as a post-filter over all
-results. This matters here because Files dominate the graph (98% of nodes); without filtering,
-a nearest-neighbor query would return almost exclusively files regardless of what the caller
-asked for. With the filter, each entity type gets its own fair ranking: the query
-`collection.query(query_embeddings=[vec], where={"type": "Study"}, n_results=10)` returns
-the 10 most similar Study nodes directly. As new entity types are added to the KG and
-embedded, they become queryable by type immediately without code changes — just pass a
-different `where` clause.
 
 ### References
 

--- a/scripts/rdf_to_edgelist.py
+++ b/scripts/rdf_to_edgelist.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Convert NF KG RDF (Turtle) files to an edgelist for node embedding with PecanPy.
+
+Extracts all triples where both subject and object are IRIs, producing a
+weighted edgelist where edge weight is the number of distinct predicates
+connecting each (subject, object) pair. Literal-object triples are skipped
+since literals are not embeddable graph nodes.
+
+PecanPy (https://github.com/krishnanlab/PecanPy) expects:
+    node1 node2 [weight]
+
+Usage:
+    python scripts/rdf_to_edgelist.py
+    python scripts/rdf_to_edgelist.py --rdf-dir data/rdf --output data/embeddings/kg.edgelist
+    python scripts/rdf_to_edgelist.py --exclude rdf:type --unweighted
+
+Examples:
+    # Generate weighted edgelist (default)
+    python scripts/rdf_to_edgelist.py
+
+    # Skip rdf:type edges (class membership) to focus on domain relations
+    python scripts/rdf_to_edgelist.py --exclude http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from pyoxigraph import NamedNode, RdfFormat, Store
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+DEFAULT_RDF_DIR = Path("data/rdf")
+DEFAULT_OUTPUT = Path("data/embeddings/kg.edgelist")
+
+
+def load_rdf(rdf_dir: Path) -> Store:
+    store = Store()
+    ttl_files = sorted(rdf_dir.glob("*.ttl"))
+    if not ttl_files:
+        logger.error("No .ttl files found in %s", rdf_dir)
+        sys.exit(1)
+    for ttl in ttl_files:
+        logger.info("Loading %s", ttl.name)
+        with open(ttl, "rb") as f:
+            try:
+                store.bulk_load(f, RdfFormat.TURTLE)
+            except Exception as exc:
+                logger.warning("Skipping %s — parse error: %s", ttl.name, exc)
+    logger.info("Loaded %d total triples", len(store))
+    return store
+
+
+def extract_edges(
+    store: Store, exclude: set[str]
+) -> dict[tuple[str, str], int]:
+    """Return {(src, dst): edge_weight} where weight = # distinct predicates."""
+    edge_predicates: dict[tuple[str, str], set[str]] = defaultdict(set)
+    skipped_excluded = 0
+    skipped_literals = 0
+
+    for quad in store.quads_for_pattern(None, None, None):
+        subj = quad.subject
+        obj = quad.object
+        pred = quad.predicate
+
+        if not isinstance(obj, NamedNode):
+            skipped_literals += 1
+            continue
+
+        pred_str = pred.value
+        if pred_str in exclude:
+            skipped_excluded += 1
+            continue
+
+        edge_predicates[(subj.value, obj.value)].add(pred_str)
+
+    logger.info(
+        "Extracted %d unique (src, dst) pairs; skipped %d literals, %d excluded-predicate triples",
+        len(edge_predicates),
+        skipped_literals,
+        skipped_excluded,
+    )
+    return {pair: len(preds) for pair, preds in edge_predicates.items()}
+
+
+def write_edgelist(
+    edges: dict[tuple[str, str], int], output: Path, weighted: bool
+) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with open(output, "w") as f:
+        for (src, dst), weight in edges.items():
+            if weighted:
+                f.write(f"{src}\t{dst}\t{weight}\n")
+            else:
+                f.write(f"{src}\t{dst}\n")
+    logger.info("Wrote %d edges to %s", len(edges), output)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--rdf-dir",
+        type=Path,
+        default=DEFAULT_RDF_DIR,
+        help=f"Directory containing .ttl files (default: {DEFAULT_RDF_DIR})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output edgelist path (default: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--exclude",
+        nargs="*",
+        default=[],
+        metavar="IRI",
+        help="Predicate IRIs to exclude (full IRI strings)",
+    )
+    parser.add_argument(
+        "--unweighted",
+        action="store_true",
+        help="Omit edge weights (default: include weights)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.rdf_dir.exists():
+        logger.error("RDF directory not found: %s", args.rdf_dir)
+        return 1
+
+    store = load_rdf(args.rdf_dir)
+    edges = extract_edges(store, exclude=set(args.exclude))
+    write_edgelist(edges, args.output, weighted=not args.unweighted)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Add scripts and docs for deriving node embeddings (graph embeddings). Pipeline first outputs an edgelist then uses PecanPy (node2vec) with tested, reasonable default parameters. Note that for now this has not been added to the main KG build workflow, because it's considered an optional add-on that extends build time non-trivially (~7 min on 16 cores, significantly longer on GH-hosted runners with 2 vCPUs). It is recommended to generate embeddings locally or on our AWS infra instead. The new publish-embeddings workflow is included for special releases that opt into publishing embeddings alongside the RDF — it is triggered manually against a specific build run, archives both the edgelist and the `.emd` file to Synapse, and updates `data_sources.yaml` with the archive IDs.
