### PR TITLE
Add SageBrain distribution

### DIFF
--- a/.github/workflows/archive-rdf.yml
+++ b/.github/workflows/archive-rdf.yml
@@ -1,11 +1,10 @@
 # Archive RDF snapshot to Synapse and generate incremental diff after a successful build.
-# Runs as a separate workflow so Synapse failures never block image publishing.
+# Runs as a separate workflow so Synapse failures never block image publishing. 
+# This can support V1/Strategy A described in internal docs [here](https://sagebionetworks.jira.com/wiki/spaces/SageBrain/pages/4667113475/Neptune+Loading+Strategy#Strategy-A-%E2%80%94-Incremental-Delta-via-SPARQL-UPDATE-LOAD%2FUNLOAD) 
 name: Archive and diff RDF
 
 on:
-  workflow_run:
-    workflows: ["Build image"]
-    types: [completed]
+  workflow_dispatch:  # disabled; restore workflow_run trigger once we confirm we want snapshots and diffs
 
 jobs:
   archive-diff:
@@ -26,7 +25,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Python dependencies
-        run: pip install -e ./orchestration numpy pyyaml
+        run: pip install -e ./orchestration numpy pyyaml pyoxigraph
 
       - name: Download RDF artifacts from build
         uses: actions/download-artifact@v7

--- a/.github/workflows/upload-sagebrain-s3.yml
+++ b/.github/workflows/upload-sagebrain-s3.yml
@@ -1,0 +1,57 @@
+# Upload RDF graph data to SageBrain S3 after a successful build.
+# Implements the S3 upload step per:
+#   https://github.com/Sage-Bionetworks-IT/sagebrain-infra#2-upload-data-to-s3
+#
+# Data is stored under a portal-scoped, date-partitioned prefix:
+#   s3://<bucket>/{portal}/YYYY-MM-DD/schema/
+#   s3://<bucket>/{portal}/YYYY-MM-DD/data/rdf/
+#
+# Runs as a separate workflow so upload failures never block Synapse archiving.
+# Requires secret: SAGEBRAIN_ROLE_ARN (IAM role in sagebrain-prod for OIDC auth)
+# Bucket name is stable (CDK-generated suffix) and set directly in NEPTUNE_BUCKET env var.
+
+name: Upload to SageBrain S3
+
+on:
+  workflow_run:
+    workflows: ["Build image"]
+    types: [completed]
+
+env:
+  AWS_REGION: us-east-1
+  NEPTUNE_BUCKET: app-prod-neptune-neptunedatabucketb8719d9a-jfo3bsfisgfn
+  PORTAL: nf
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  upload:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Download RDF artifacts from build
+        uses: actions/download-artifact@v7
+        with:
+          name: kg-data
+          path: .
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.SAGEBRAIN_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload to S3
+        # Note: if two builds run on the same day, the second overwrites the first.
+        # This is acceptable — Neptune loads the latest data for a given date.
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          PREFIX=s3://${{ env.NEPTUNE_BUCKET }}/${{ env.PORTAL }}/$DATE
+          aws s3 cp schema/   $PREFIX/schema/   --recursive
+          aws s3 cp data/rdf/ $PREFIX/data/rdf/ --recursive

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ python scripts/archive_rdf.py --comment "Build v1.2.0"
 Both steps run automatically in CI after `make all` and RDF validation.
 The archive requires `SYNAPSE_AUTH_TOKEN` to be set.
 
+### SageBrain / Neptune Distribution
+
+After each successful build, RDF graph data (`schema/` and `data/rdf/`) is uploaded to the SageBrain Neptune S3 bucket under a date-partitioned prefix (`nf/YYYY-MM-DD/`). This requires the `SAGEBRAIN_ROLE_ARN` secret to be set for OIDC authentication.
+
 ### Build and Release
 
 Pre-built [QLever](https://github.com/ad-freiburg/qlever) images with indexed data


### PR DESCRIPTION
Close #59. Implement "Strategy B" of how to distribute data to SageBrain; this also automates the loading, which is currently manual. `SAGEBRAIN_ROLE_ARN` needs to be obtained and set in repo for this to run successfully, otherwise disable in GitHub UI until role ARN is handed out to us. We also disable "Strategy A" workflow that was part of the first idea (which was not a bad idea, we just want to keep it simpler for now). The other workflow can always be reinstated later. Helpful reference to discussion [here](https://sagebionetworks.slack.com/archives/C09BT1B4Z4P/p1778601613408029).